### PR TITLE
Add Support for Metric versus Imperial Units

### DIFF
--- a/STEP Navigation/Adapters/TextFeedbackAdapter.swift
+++ b/STEP Navigation/Adapters/TextFeedbackAdapter.swift
@@ -372,19 +372,30 @@ class Navigation {
         if (displayDistance) {
                 // don't use fractional feet or for higher numbers of meters (round instead)
                 // Related to higher number of meters, there is a somewhat strange behavior in VoiceOver where numbers greater than 10 will be read as, for instance, 11 dot 4 meters (instead of 11 point 4 meters).
-            altText += " " + NSLocalizedString("and walk ", comment: "this text is presented when getting directions.  It is placed between a direction of how to turn and a distance to travel") + distanceToUnitString(distanceInMeters: distance)
+            altText += " " + NSLocalizedString("and walk ", comment: "this text is presented when getting directions.  It is placed between a direction of how to turn and a distance to travel") + distance.metersAsUnitString
         }
         return altText
     }
-    
+}
+
+extension Float {
     /// Convert distance in meters to a string suitable for displaying to the user.  This function handles unit conversions for distance depending on the user's selections in the settings
     /// - Parameter distanceInMeters: the distance in meters
     /// - Returns: a string containing information about how far the distance is along with its units
-    private func distanceToUnitString(distanceInMeters: Float)->String {
-        if SettingsManager.shared.units { // metric
-            return  "\(roundToTenths(distanceInMeters)) meters"
+    var metersAsUnitString:String {
+        return Double(self).metersAsUnitString
+    }
+}
+
+extension Double {
+    /// Convert distance in meters to a string suitable for displaying to the user.  This function handles unit conversions for distance depending on the user's selections in the settings
+    /// - Parameter distanceInMeters: the distance in meters
+    /// - Returns: a string containing information about how far the distance is along with its units
+    var metersAsUnitString:String {
+        if SettingsManager.shared.useMetricDistanceUnits { // metric
+            return  "\(roundToTenths(self)) meters"
         } else {
-            let feet = Int(distanceInMeters * Float(100.0/2.54/12.0))
+            let feet = Int(self * Double(100.0/2.54/12.0))
             return  "\(Int(feet)) feet"
         }
     }
@@ -396,3 +407,7 @@ func roundToTenths(_ n: Float) -> Float {
     return roundf(10 * n)/10
 }
 
+/// - Returns: the number rounded to the nearest tenth
+func roundToTenths(_ n: Double) -> Double {
+    return round(10 * n)/10
+}

--- a/STEP Navigation/Adapters/TextFeedbackAdapter.swift
+++ b/STEP Navigation/Adapters/TextFeedbackAdapter.swift
@@ -368,14 +368,25 @@ class Navigation {
     ///   - distance: the distance (expressed in meters)
     ///   - displayDistance: a Boolean that indicates whether to display the distance (true means display distance)
     func updateDirectionText(_ description: String, distance: Float, displayDistance: Bool)->String {
-        let distanceToDisplay = roundToTenths(distance * Float(100.0/2.54/12.0))
         var altText = description
         if (displayDistance) {
                 // don't use fractional feet or for higher numbers of meters (round instead)
                 // Related to higher number of meters, there is a somewhat strange behavior in VoiceOver where numbers greater than 10 will be read as, for instance, 11 dot 4 meters (instead of 11 point 4 meters).
-            altText += " " + NSLocalizedString("and walk", comment: "this text is presented when getting directions.  It is placed between a direction of how to turn and a distance to travel") + " \(Int(distanceToDisplay)) feet"
+            altText += " " + NSLocalizedString("and walk ", comment: "this text is presented when getting directions.  It is placed between a direction of how to turn and a distance to travel") + distanceToUnitString(distanceInMeters: distance)
         }
         return altText
+    }
+    
+    /// Convert distance in meters to a string suitable for displaying to the user.  This function handles unit conversions for distance depending on the user's selections in the settings
+    /// - Parameter distanceInMeters: the distance in meters
+    /// - Returns: a string containing information about how far the distance is along with its units
+    private func distanceToUnitString(distanceInMeters: Float)->String {
+        if SettingsManager.shared.units { // metric
+            return  "\(roundToTenths(distanceInMeters)) meters"
+        } else {
+            let feet = Int(distanceInMeters * Float(100.0/2.54/12.0))
+            return  "\(Int(feet)) feet"
+        }
     }
         
 }

--- a/STEP Navigation/Models/SettingsManager.swift
+++ b/STEP Navigation/Models/SettingsManager.swift
@@ -25,7 +25,7 @@ class SettingsManager: ObservableObject {
     @Published var adjustPhoneBodyOffset = false
     
     /// boolean to toggle the units between imperial and metric. false for imperial units, true for metric units
-    @Published var units = false
+    @Published var useMetricDistanceUnits = false
     
     /// true if we should provide the user with guidance when they appear to be lost
     @Published var automaticDirectionsWhenUserIsLost = false
@@ -57,7 +57,7 @@ class SettingsManager: ObservableObject {
         adjustPhoneBodyOffset = defaults.bool(forKey: "adjustPhoneBodyOffset")
         automaticDirectionsWhenUserIsLost = defaults.bool(forKey: "automaticDirectionsWhenUserIsLost")
         visualizeStreetscapeData = defaults.bool(forKey: "visualizeStreetscapeData")
-        units = defaults.bool(forKey: "units")
+        useMetricDistanceUnits = defaults.bool(forKey: "units")
 
     }
     
@@ -68,7 +68,7 @@ class SettingsManager: ObservableObject {
             "adjustPhoneBodyOffset": false,
             "automaticDirectionsWhenUserIsLost": false,
             "visualizeStreetscapeData": false,
-            "units": false
+            "units": Locale.current.measurementSystem == .metric
         ]
         UserDefaults.standard.register(defaults: appDefaults)
     }

--- a/STEP Navigation/Settings.bundle/Root.plist
+++ b/STEP Navigation/Settings.bundle/Root.plist
@@ -10,7 +10,7 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
-			<string>Units</string>
+			<string>Use Metric Distance Units</string>
 			<key>Key</key>
 			<string>units</string>
 			<key>DefaultValue</key>

--- a/STEP Navigation/Views/Assets/Miscellaneous.swift
+++ b/STEP Navigation/Views/Assets/Miscellaneous.swift
@@ -31,7 +31,7 @@ struct AnchorDetailsText: View {
             }
             
             HStack {
-                    Text("\(String(format: "%.0f", distanceAway)) meters away") //TODO: make this dynamic so it can be imperial or metric
+                Text("\(distanceAway.metersAsUnitString) away")
                         .font(.title)
                         .padding(.horizontal)
                 Spacer()

--- a/STEP Navigation/Views/DestinationTypesView.swift
+++ b/STEP Navigation/Views/DestinationTypesView.swift
@@ -21,8 +21,7 @@ struct DestinationTypesView: View {
             let anchorTypes = PositioningModel.shared.currentLatLon != nil ? DataModelManager.shared.getNearbyDestinationCategories(location: PositioningModel.shared.currentLatLon!, maxDistance: nearbyDistance) : []
             
             VStack {
-                let nearbyDistanceString = String(format: "%.0f", $nearbyDistance.wrappedValue)
-                ScreenHeader(title: "Destinations", subtitle: "Within \(nearbyDistanceString) meters")
+                ScreenHeader(title: "Destinations", subtitle: "Within \(nearbyDistance.metersAsUnitString)")
                 
                 ScrollView {
                     VStack(spacing: 24) {

--- a/STEP Navigation/Views/SettingsDetailViews.swift
+++ b/STEP Navigation/Views/SettingsDetailViews.swift
@@ -177,7 +177,7 @@ struct ColorSchemes: Identifiable {
 }
 
 struct SettingsDetailView_Units: View {
-    @State private var selected: Bool = SettingsManager.shared.units
+    @State private var selected: Bool = SettingsManager.shared.useMetricDistanceUnits
     
     var body: some View {
         ScreenBackground {


### PR DESCRIPTION
I modified the text used for the units to specify "Use Metric Distance Units" rather than "Units"
Make sure to respect this settings in all places where we display distance sin the app.
Set the default for units based on the user's current locale